### PR TITLE
Reload the workflow instance entity before saving it to a persistent storage

### DIFF
--- a/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
+++ b/src/WorkflowCore/Services/BackgroundTasks/WorkflowConsumer.cs
@@ -55,6 +55,9 @@ namespace WorkflowCore.Services.BackgroundTasks
                     finally
                     {
                         WorkflowActivity.Enrich(result);
+                        var updatedWorkflow = await _persistenceStore.GetWorkflowInstance(itemId, cancellationToken);
+                        updatedWorkflow.ExecutionPointers = workflow.ExecutionPointers;
+                        workflow = updatedWorkflow;
                         await _persistenceStore.PersistWorkflow(workflow, result?.Subscriptions, cancellationToken);
                         await QueueProvider.QueueWork(itemId, QueueType.Index);
                         _greylist.Remove($"wf:{itemId}");


### PR DESCRIPTION
**Describe the change**
Reload the workflow instance entity before saving it to a persistent storage after a workflow item is processed.

**Breaking change**
It is not a breaking change.

**Additional context**
The bug was observed: the suspend workflow functionality is not working - the 'suspended' status is reset after the currently running step is finished.
The root cause is that the most recent `workflow.Status` (suspended) was overwritten with the initial status (running).