### PR TITLE
Do not specify 'PackageId' in the 'dotnet pack' params

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -12,6 +12,7 @@ jobs:
       DOTNET_VERSION: '6.0.x'
       DOTNET_NOLOGO: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
+      ARTIFACTS_DIR: './artifacts/nuget/cvm.workflowcore'
       PROJECT_WORKFLOWCORE: 'src/WorkflowCore/WorkflowCore.csproj'
       PKG_NAME_WORKFLOWCORE: 'WorkflowCore'
       PROJECT_WORKFLOWCORE_MONGODB: 'src/providers/WorkflowCore.Persistence.MongoDB/WorkflowCore.Persistence.MongoDB.csproj'
@@ -47,13 +48,13 @@ jobs:
         run: dotnet build ${{ env.PROJECT_WORKFLOWCORE_DSL }} --configuration Release -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-restore
 
       - name: Pack '${{ env.PKG_NAME_WORKFLOWCORE }}'
-        run: dotnet pack ${{ env.PROJECT_WORKFLOWCORE }} --configuration Release --output ./artifacts/nuget/cvm.workflowcore -p:PackageId="Dodo.Cvm.${{ env.PKG_NAME_WORKFLOWCORE }}" -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-build
+        run: dotnet pack ${{ env.PROJECT_WORKFLOWCORE }} --configuration Release --output ${{ env.ARTIFACTS_DIR }} -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-build
 
       - name: Pack '${{ env.PKG_NAME_WORKFLOWCORE_MONGODB }}'
-        run: dotnet pack ${{ env.PROJECT_WORKFLOWCORE_MONGODB }} --configuration Release --output ./artifacts/nuget/cvm.workflowcore -p:PackageId="Dodo.Cvm.${{ env.PKG_NAME_WORKFLOWCORE_MONGODB }}" -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-build
+        run: dotnet pack ${{ env.PROJECT_WORKFLOWCORE_MONGODB }} --configuration Release --output ${{ env.ARTIFACTS_DIR }} -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-build
 
       - name: Pack '${{ env.PKG_NAME_WORKFLOWCORE_DSL }}'
-        run: dotnet pack ${{ env.PROJECT_WORKFLOWCORE_DSL }} --configuration Release --output ./artifacts/nuget/cvm.workflowcore -p:PackageId="Dodo.Cvm.${{ env.PKG_NAME_WORKFLOWCORE_DSL }}" -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-build
+        run: dotnet pack ${{ env.PROJECT_WORKFLOWCORE_DSL }} --configuration Release --output ${{ env.ARTIFACTS_DIR }} -p:Version=${{ steps.extract_version.outputs.VERSION }} --no-build
 
       - name: Push NuGet Packages
-        run: dotnet nuget push ./artifacts/nuget/cvm.workflowcore/*.nupkg --source ${{ secrets.NUGET_SOURCE }} --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+        run: dotnet nuget push ${{ env.ARTIFACTS_DIR }}/*.nupkg --source ${{ secrets.NUGET_SOURCE }} --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate


### PR DESCRIPTION
Do not specify 'PackageId' in the 'dotnet pack' params because it breaks the dependency between the MongoDB persistence provider and the referenced 'WorkflowCore' project